### PR TITLE
Lychee keeps opening issues when things are fine

### DIFF
--- a/.github/workflows/broken-link-checker.yaml
+++ b/.github/workflows/broken-link-checker.yaml
@@ -16,6 +16,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Create Issue From File
+        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v4.0.1
         with:
           title: Link Checker Report


### PR DESCRIPTION
Lychee keeps opening issues when the link checker is fine.

Setting it so that if the link check exists with not `0` (success) then it will make an issue

Fixes #44 
Fixes #43 